### PR TITLE
正则表达式优化: 排除除http(s)外协议前缀的js路径

### DIFF
--- a/content/content.js
+++ b/content/content.js
@@ -451,7 +451,7 @@ async function collectAndScanResources(depth = 0, maxDepth = 3, tabId) {
       }
 
       // 从内容中匹配JS URL
-      const jsPattern = /['"](?:[^'"]+\.(?:js)(?:\?[^\s'"]*)?)['"]/g;
+      const jsPattern = /['"](?:https?:\/\/[^\s'"]+\.js(?:\?[^\s'"]*)?|[^:'"]+\.js(?:\?[^\s'"]*)?)['"]/g;
       const matches = Array.from(content.matchAll(jsPattern))
         .map(match => {
           const path = match[0].slice(1, -1);


### PR DESCRIPTION
正则表达式优化：排除除 http(s) 外自定义协议前缀的 js 路径

- 仅支持匹配普通、相对路径及 http(s) 协议的 .js 文件路径
- 避免误匹配如 "common-new:widget/lib/jquery/jquery.origin.js" 等情况